### PR TITLE
Fix for coffee generator

### DIFF
--- a/templates/mongo/config/environment.coffee
+++ b/templates/mongo/config/environment.coffee
@@ -3,7 +3,7 @@ express    = require 'express'
 
 if process.env.MONGOHQ_URL
     app.settings.mongoUrl = process.env.MONGOHQ_URL
-    var m = require('url').parse process.env.MONGOHQ_URL
+    m = require('url').parse process.env.MONGOHQ_URL
     app.settings.db =
         driver:   'mongoose'
         database: m.pathname.replace(/^\//, '')

--- a/templates/server.coffee
+++ b/templates/server.coffee
@@ -3,5 +3,5 @@
 app = module.exports = require('railway').createServer()
 
 if not module.parent
-    app.listen 3000
+    app.listen process.env.PORT || 3000
     console.log "Express server listening on port %d", app.address().port


### PR DESCRIPTION
Found 2 small issues in .coffee templates. One was a reserved word "var" on line 6 of environment.coffee and the other was a missing PORT environment variable in the server.coffee that was causing Heroku not to connect to the mongo db.
