### PR TITLE
added ability to override default css and js folders

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -13,7 +13,7 @@ var utils = require('./railway_utils'),
       'css': '.css',
       'js' : '.js'
     },
-    paths      = {
+    paths = {
       'css': '/stylesheets/',
       'js' : '/javascripts/'
     },
@@ -44,6 +44,7 @@ function HelperSet(ctl) {
             '<meta name="csrf-token" content="' + controller.request.csrfToken + '"/>'
         ].join('\n') : '';
     }
+
 }
 
 function checkProd() {
@@ -73,12 +74,17 @@ module.exports.personalize = function (controller) {
 
 // <link href="/stylesheets/all.css"  media="screen" rel="stylesheet" type="text/css" />
 HelperSet.prototype.stylesheet_link_tag = function () {
+    if (!paths.css || !paths.stylesheets) {
+      paths.css = app.settings.cssDirectory || '/stylesheets/';
+      paths.stylesheets = paths.css;
+    }
+  
     var args = Array.prototype.slice.call(arguments);
     var options = {media: 'screen', rel: 'stylesheet', type: 'text/css'};
+    var links = [];
     if (typeof args[args.length - 1] == 'object') {
         options = safe_merge(options, args.pop());
     }
-    var links = [];
     mergeFiles('stylesheets', args).forEach(function (file) {
         delete options.href;
         // there should be an option to change the /stylesheets/ folder
@@ -101,6 +107,10 @@ HelperSet.prototype.stylesheet_link_tag = function () {
  *   <script type="text/javascript" src="/javascripts/application.js"></script>
  */
 HelperSet.prototype.javascript_include_tag = function () {
+    if (!paths.js || !paths.javascripts) {
+      paths.js = app.settings.jsDirectory || '/javascripts/'
+      paths.javascripts = paths.js;
+    }
     var args = Array.prototype.slice.call(arguments);
     var options = {type: 'text/javascript'};
     if (typeof args[args.length - 1] == 'object') {
@@ -108,6 +118,7 @@ HelperSet.prototype.javascript_include_tag = function () {
     }
     var scripts = [];
     mergeFiles('javascripts', args).forEach(function (file) {
+        // there should be an option to change the /javascripts/ folder
         var href = checkFile('js', file);
         delete options.src;
         scripts.push(generic_tag('script', '', options, {src: href}));
@@ -128,8 +139,8 @@ function mergeFiles(scope, files) {
     var ext  = merged[scope].ext,
       result = [],
       shasum = crypto.createHash('sha1'),
-      minify = [];
-
+      minify = [],
+      directory = merged[scope].directory = paths[scope].replace(/(\/+)/g, '');
     // only merge local files
     files.forEach(function (file) {
         if (!regexps.isHttp.test(file)) {
@@ -156,15 +167,15 @@ function mergeFiles(scope, files) {
             // mark caching process as started
             merged[scope][digest] = false;
             // write resulted script as merged `minify` files
-            var stream = fs.createWriteStream(path.join(app.root, 'public', scope, 'cache', digest + ext));
+            var stream = fs.createWriteStream(path.join(app.root, 'public', directory, 'cache', digest + ext));
             var counter = 0;
             minify.forEach(function (file) {
-                var filename = path.join(app.root, 'public', scope, file + ext);
+                var filename = path.join(app.root, 'public', directory, file + ext);
                 path.exists(filename, function (exists) {
                     if (exists) {
                         counter += 1;
                         fs.readFile(filename, 'utf8', function (err, data) {
-                            stream.write('// /' + scope + '/' + file + ext + '\n');
+                            stream.write('// /' + directory + '/' + file + ext + '\n');
                             stream.write(data + '\n');
                             done();
                         });

--- a/templates/config/environment.js
+++ b/templates/config/environment.js
@@ -5,10 +5,11 @@ app.configure(function(){
     app.use(express.static(cwd + '/public', {maxAge: 86400000}));
     app.set('views', cwd + '/app/views');
     app.set('view engine', 'VIEWENGINE');
+    app.set('jsDirectory', '/javascripts/');
+    app.set('cssDirectory', '/stylesheets/');
     app.use(express.bodyParser());
     app.use(express.cookieParser());
     app.use(express.session({secret: 'secret'}));
     app.use(express.methodOverride());
     app.use(app.router);
 });
-


### PR DESCRIPTION
another one i forgot to add previously.  seems to work fine on my local copy.  it caches the css and js files to their respective, overridden folders.  I left it set to "/stylesheets/" and "/javascripts/" for default build purposes though.  i currently have mine set to "/css/" and "/js/".

oh and i did realize how to make it so that only minimal commits would come through now =)

dale
