### PR TITLE
resource middleware

### DIFF
--- a/lib/route_mapper.js
+++ b/lib/route_mapper.js
@@ -107,7 +107,15 @@ function Mapper (app) {
                 observer = ActionObserver.get(subpath.toString(), controller, ns + controller);
             }
 
-            if (typeof before_filter !== 'function' && typeof options === 'undefined') {
+            // only accept functions in before filter when its an array
+            if (before_filter instanceof Array) {
+                var before_filter_functions = before_filter.filter(function(filter) {
+                   return (typeof filter === 'function');
+                });
+                before_filter = before_filter_functions.length > 0 ? before_filter_functions : null;
+            }
+
+            if (!(typeof before_filter === 'function' || (before_filter instanceof Array)) && typeof options === 'undefined') {
                 options = before_filter;
                 before_filter = null;
             }


### PR DESCRIPTION
This fix allows a resources middleware parameter to accept either a function or an array.  If an array is used then only functions are used, anything else gets ignored.
