### PR TITLE
Better handling YAML and unknown/bad locale files in locales.load()

### DIFF
--- a/lib/locales.js
+++ b/lib/locales.js
@@ -21,17 +21,21 @@ exports.load = function (dir) {
         var code = fs.readFileSync(filename, 'utf8').toString();
         var obj;
         try {
-            if (file.match(/\.yml$/)) {
-                obj = yaml.eval(code);
+            if (file.match(/\.ya?ml$/)) {
+                obj = yaml.eval(code.replace(/\r\n?/g,'\n'));
             } else if (file.match(/\.json/)) {
                 obj = JSON.parse(code);
+            } else {
+                console.log('Unsupported extension of locale file ' + filename);
             }
         } catch (e) {
             console.log('Parsing file ' + filename);
             console.log(e);
             console.log(e.stack);
         }
-        addTranslation(obj);
+        if (obj) {
+            addTranslation(obj);
+        }
     });
 };
 


### PR DESCRIPTION
1. Preprocess YAML files to replace &lt;CR&gt;&lt;LF&gt; (or &lt;CR&gt;-only, just in case) line endings (<i>think Windows files</i>) with &lt;LF&gt; so that the YAML module can handle them -- it cannot do that successfully right now (and I don't feel certain if it should be expected to -- I consider it quite practical to prepare the file contents a little bit in this particular case). This fix is important to all who, like me, is developing with express-on-railway with node.js on Windows.
2. Allow both .yml and .yaml extension of locale files (the .yaml extension is quite widely used for YAML files).
3. Minor changes to make locales.load() handling the bad/unknown files in config/locales smoother. (If you feel like silently ignoring the locale files with unknown extensions, feel free to drop the else branch with the log message).
