### PR TITLE
Init t.locale to app.settings.defaultLocale in Controller()

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -81,7 +81,7 @@ function Controller(name) {
         afterFilters.push(filter(arguments));
     };
 
-    this.prependAfter = this.prependAfter = function (f, params) {
+    this.prependAfter = this.prependAfterFilter = function (f, params) {
         afterFilters.unshift(filter(arguments));
     };
 


### PR DESCRIPTION
This way extra calls to <b>Controller.setLocale()</b> are not required when the default app setting is present and is what the developer wants. This change also fixes/improves the behavior of <b>locales.T.t()</b> where the locale value is now explicitly assumed to be <b>'en'</b> if <b>t.locale</b> is undefined.

BTW, thinking aloud: Maybe it would be better to fully remove the "<b> || 'en' </b>" part from <b>T.t()</b> in <b>locales</b>? -- and instead set <b>t.locale</b> in <b>Controller()</b> as follows:

<b>this.t.locale =  app.settings.defaultLocale || 'en';</b>

I suppose that would be a more consistent approach -- what do you think?
