### PR TITLE
Handle undefined app.settings.translationMissing as if it is set to 'default'

### DIFF
--- a/lib/locales.js
+++ b/lib/locales.js
@@ -96,6 +96,7 @@ function T(global) {
         case 'display':
             return 'translation missing for ' + locale + '.' + path;
         case 'default':
+        case undefined:
             var defLocale = app.settings.defaultLocale;
             return !defLocale || locale === defLocale ? '' : translate(path, defLocale);
         }


### PR DESCRIPTION
If believe it would be better to apply the default behavior in <b>locales.t.translationMissing()</b> both when <b>app.settings.translationMissing</b> is explicitly set to 'default' and when it is undefined.
