### PR TITLE
Some optimizations in locales.T.translate

### DIFF
--- a/lib/locales.js
+++ b/lib/locales.js
@@ -74,16 +74,22 @@ function T(global) {
     function translate(path, locale, defaultValue) {
         var translation = localeData[locale], substitute;
 
+        function nextPathItem(token) {
+            return (translation = translation[token]);
+        }
+
         if (typeof path === 'string') {
             substitute = false;
         } else {
             substitute = path;
             path = substitute.shift();
         }
-        path.split('.').forEach(function (pathToken) {
-            translation = translation && translation[pathToken] || defaultValue || translationMissing(locale, path);
-        });
-        if (substitute && substitute.length) {
+
+        if (!translation || !path.split('.').every(nextPathItem)) {
+            translation = defaultValue || translationMissing(locale, path);
+        }
+
+        if (translation && substitute && substitute.length) {
             substitute.forEach(function (substitution) {
                 translation = translation.replace(/%/, substitution.toString().replace(/%/g, ''));
             });


### PR DESCRIPTION
I would like to suggest making <b>locales.T.translate</b> slightly more efficient in the case when the required path (chain of keys in the tree of assoc. arrays) does not exist for the specific locale: Currently, even if the traversal fails in the middle of the path, the <b>forEach</b> loop will force try-and-fail for all the remaining path tokens -- plus on each of those extra iterations both <b>defaultValue</b> and <b>translationMissing</b> will be called repeatedly. This is what the proposed changes address.

Also, adding an extra check to avoid an attempt to substitute params if the required translation was not found.
