### PR TITLE
a minor bug on 0.2.8

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -309,7 +309,7 @@ function Controller(name) {
 
     var buffer = {};
     this.publish = this.export = function (name, obj) {
-        if (typeof name !== string && typeof obj.name === 'string') {
+        if (typeof name !== 'string' && typeof obj.name === 'string') {
             obj = name;
             name = obj.name;
         }


### PR DESCRIPTION
just missed a simple quotes in "/lib/controller.js", Line 312 for "string" keyword.
