### PR TITLE
Simple fix for allowing nested namespaces within routes

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -450,7 +450,7 @@ exports.addBasePath = function (basePath, prefix, context) {
                     Controller.context[ctl] = Controller.context[ctl] || context;
                 }
             } else if (stat.isDirectory()) {
-                exports.addBasePath(path.join(basePath, file), file + '/');
+                exports.addBasePath(path.join(basePath, file), prefix + file + '/');
             }
         });
     }


### PR DESCRIPTION
Allows the following within the routes file:

``` javascript
map.namespace('api', function (api) {
  api.namespace('v1', function (v1) {
    v1.resources('boards');
  });
});
```
