### PR TITLE
Initialize Locales before Model

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -32,6 +32,10 @@ function prepareContext(exportModels, defSchema, done) {
 
     done = done || function () {};
 
+    this.t = T();
+    this.t.locale = app.settings.defaultLocale || 'en';
+    this.T = T;
+
     /**
      * Multiple schemas support
      * example:

--- a/lib/onrailway.js
+++ b/lib/onrailway.js
@@ -54,6 +54,8 @@ exports.init = function (app) {
     // extensions should be loaded before server startup
     railway.extensions.init();
 
+	railway.locales.init();
+
     railway.models.init();
 
     // run config/initializers/*
@@ -65,7 +67,6 @@ exports.init = function (app) {
 
     process.nextTick(function () {
 
-        railway.locales.init();
         railway.logger.init();
         app.reloadModels = railway.models.loadModels;
 


### PR DESCRIPTION
I think, it's really useful to have locale in models, to set default value with specific translation, and it's really useful when using railway-SQLFORM to define label, comment...etc.
