### PR TITLE
Create a new helper csrf_tag to create the hidden input tag

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -209,7 +209,7 @@ HelperSet.prototype.form_tag = function (params, block) {
 
     // push output
     buf.push('<form' + htmlTagParams(params) + '>');
-    buf.push('<input type="hidden" name="' + this.controller.request.csrfParam + '" value="' + this.controller.request.csrfToken + '" />');
+    buf.push( this.csrf_tag() );
 
     // alternative method?
     if (_method !== params.method) {
@@ -289,6 +289,10 @@ HelperSet.prototype.input_tag = function (params, override) {
 HelperSet.prototype.label_tag = function (text, params, override) {
     return genericTag('label', text, params, override);
 };
+
+HelperSet.prototype.csrf_tag = function() {
+    return '<input type="hidden" name="' + this.controller.request.csrfParam + '" value="' + this.controller.request.csrfToken + '" />';
+}
 
 HelperSet.prototype.sanitize = sanitizeHTML;
 


### PR DESCRIPTION
That way it can be used in custom forms.
