### PR TITLE
Add function to load all controllers

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -721,6 +721,12 @@ exports.load = function (name) {
     }
 };
 
+exports.loadAll = function() {
+    Object.getOwnPropertyNames(Controller.index).forEach(function(c) {
+        exports.load(c)._init();
+    });
+};
+
 /**
  * @private
  */


### PR DESCRIPTION
It is sometimes desirable to load all controller code after initializing the application. So provide a function that will load and init all controllers.
