### PR TITLE
fix for global leaking variables

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -233,7 +233,8 @@ HelperSet.prototype.formTag = function (params, block) {
     }
 
     // hook up alternative methods (PUT, DELETE)
-    var method = _method = params.method.toUpperCase();
+    var _method,
+        method = _method = params.method.toUpperCase();
     if (method != 'GET' && method != 'POST') {
         _method = method;
         params.method = 'POST';
@@ -288,11 +289,10 @@ HelperSet.prototype.errorMessagesFor = function errorMessagesFor(resource) {
  * Form fields for resource helper
  */
 HelperSet.prototype.fields_for = function (resource, block) {
-    var self = this;
     arguments.callee.buf = arguments.callee.caller.buf;
     resource = resource || {};
-    resourceName = resource && resource.constructor && resource.constructor.modelName || false;
-
+    var self = this;
+    var resourceName = resource && resource.constructor && resource.constructor.modelName || false;
     var complexNames = (app.set('view options') || {}).complexNames;
 
     function makeName(name) {


### PR DESCRIPTION
In helpers.js I think I found 2 variables, that are global accessable, which I think shouldn't be.

First is in "HelperSet.prototype.fields_for" named "resourceName"
Second is in "HelperSet.prototype.formTag" named "_method"
