### PR TITLE
add extra check when loading model on crud

### DIFF
--- a/templates/crud_controller.js
+++ b/templates/crud_controller.js
@@ -68,7 +68,7 @@ action(function destroy() {
 
 function loadModel() {
     Model.find(params.id, function (err, model) {
-        if (err) {
+        if (err || !model) {
             redirect(path_to.models);
         } else {
             this.model = model;


### PR DESCRIPTION
I found a bug when trying to delete a non-existant record (the application crashes). I added an extra check to avoid this behavior on crud, but the app may still crush, this must be handled within the core.

To reproduce the error:
1) create a railway app
2) $ railway g post title description
3) run app
4) Go to http://localhost:3000/posts/new and create one post
5) When redirected in the Post index, open another tab in your browser and go to the same address (http://localhost:3000/posts).
6) On one tab, delete the record, you will be redirected to the index, and see no records, now go to the other tab (where you still can delete the record), click on delete, and you will find the error.
