### PR TITLE
added function to helpers: link_to_if_not_current

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -234,7 +234,7 @@ HelperSet.prototype.link_to = HelperSet.prototype.linkTo;
  */
 HelperSet.prototype.linkToIfNotCurrent = function linkTo(text, url, params) {
     if (url && url[0]=='/') url = url.substring(1);  //trim first '/' if exists
-    return (url == _url.parse( this.controller.request.url ).pathname.substring(1) ) ? text : HelperSet.prototype.link_to(text, url, params) ;
+    return (url.toLowerCase() == _url.parse( this.controller.request.url ).pathname.substring(1).toLowerCase() ) ? text : HelperSet.prototype.link_to(text, url, params) ;
 };
 HelperSet.prototype.link_to_if_not_current = HelperSet.prototype.linkToIfNotCurrent;
 


### PR DESCRIPTION
display a 'a href' tag only if not the current page. if current page display text without the tag.
