### PR TITLE
Fix to allow form.input to prepopulate the text fields with Mongoose.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -320,7 +320,7 @@ HelperSet.prototype.fields_for = function (resource, block) {
         input: function (name, params) {
             params = params || {};
             if (params.value === undef) {
-                params.value = resource[name] ? resource[name] : '';
+                params.value = resource[name] != undefined ? resource[name] : '';
             }
             return HelperSet.prototype.input_tag({
                 name: makeName(name),


### PR DESCRIPTION
With a Mongoose customschema, hasOwnProperty returns false whereas testing for the "value" of the resource returns the actual value.
