### PR TITLE
select helper, changed checkbox and documentation of helper.js

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -381,20 +381,20 @@ HelperSet.prototype.fields_for = function (resource, block) {
     }
     
     block({
-    	/**
-    	 * Input tag helper
-    	 *
-    	 * Example in ejs:
-    	 *
-		 *      <%- form.input("test") %>
-		 *
-		 * This returns:
-		 *
-		 *      <input name="test"/>
-		 *
-		 * @param {String} name Name of the element
-		 * @param {Object} params Additional parameters
-    	 */
+        /**
+         * Input tag helper
+         *
+         * Example in ejs:
+         *
+         *      <%- form.input("test") %>
+         *
+         * This returns:
+         *
+         *      <input name="test"/>
+         *
+         * @param {String} name Name of the element
+         * @param {Object} params Additional parameters
+         */
         input: function (name, params) {
             params = params || {};
             if (params.value === undef) {
@@ -411,11 +411,11 @@ HelperSet.prototype.fields_for = function (resource, block) {
                 params.value = resource[name] || 1;
             }
             if (params.checked === undef) {
-            	if(resource[name]) {
-                	params.checked = 'checked';
+                if(resource[name]) {
+                    params.checked = 'checked';
                 }
             } else if (params.checked === false) {
-            	delete params.checked;
+                delete params.checked;
             }
             return HelperSet.prototype.input_tag({
                 name: makeName(name),
@@ -435,16 +435,16 @@ HelperSet.prototype.fields_for = function (resource, block) {
          *
          * Example in ejs:
          *
-		 *      <%- form.label("test", false, {class: "control-label"}) %>
-		 *
-		 * This returns:
-		 *
-		 *      <label for="test" class="control-label">Test</label>
-		 *
-		 * @param {String} name Name of the element
-		 * @param {String} caption Optional different caption of the elemt
-		 * @param {Object} params Additional parameters
-		 */
+         *      <%- form.label("test", false, {class: "control-label"}) %>
+         *
+         * This returns:
+         *
+         *      <label for="test" class="control-label">Test</label>
+         *
+         * @param {String} name Name of the element
+         * @param {String} caption Optional different caption of the elemt
+         * @param {Object} params Additional parameters
+         */
         label: function (name, caption, params) {
             return HelperSet.prototype.label_tag(
                 caption || self.controller.t('models.' + resource.constructor.modelName + '.fields.' + name, humanize(name)),


### PR DESCRIPTION
Hello Anatoliy,

i'd like to push some things to railway, all related to helper.js
- Documentation according to JsDoc Toolkit guidelines
- Cleanup of examples
- Moved definition of "merged" further up to the other definitions
- Helper: checkbox
  - Added "param" as additional parameter:
    - Customized value possible
    - "checked"
      - If not defined as a parameter it works as previously (check if resource is set)
      - If set, it is set as a parameter (enables to have "always checked" boxes)
      - If set to Boolean false, check is not set (enables "always unchecked" boxes)
  - All changes are backwards compatible
- Helper: select (See #188 for my first enquiry)
  - Called with (name, options, params)
  - Possible, optional fields for "params":
    - blank: {STRING} Blank value to be added at the beginning of the list
    - fieldname: {STRING} Sets the name of the field in "options" field where the displayed values can be found. Default: "value"
    - fieldvalue:  {STRING} Sets the name of the field in "options" field where the submitted values can be found. Default = fieldname
    - multiple: Can be set to false if size >1 to only select one value.
    - select: Select a value. If fieldname and fieldvalue are different, the value is compared with fieldvalue otherwise with fieldname.
    - size: Sets the displayed size of the select field
  - Examples:

``` javascript
<%- form.select("state", states, {fieldname: 'name', select: item.state.name}) %>

<%- form.select("state", states, {fieldname: 'name', fieldvalue: '_id', select: item.state._id, size: 3, multiple: false}) %>

<%- form.select("state", states, {fieldname: 'name', fieldvalue: '_id', select: item.state._id, size: 3, blank:'Select status'}) %>
```
