### PR TITLE
made change in generateModels function to create db dir and schema file ...

### DIFF
--- a/lib/generators.js
+++ b/lib/generators.js
@@ -228,6 +228,8 @@ exports.list = function () {
             code = 'var ' + Model + ' = describe(\'' + Model + '\', function () {\n' +
             attrs.join('\n') + '\n});';
         }
+        createDir('db/');
+        createFile('db/schema' + fileExtension, '');
         railway.utils.appendToFile('db/schema' + fileExtension, code);
         return result;
     }


### PR DESCRIPTION
...if it doesn't already exist. Current functionality has the generator error out if no db/schema.js file present.
