### PR TITLE
form.input type attribute defaults to type, handling password inputs

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -407,7 +407,10 @@ HelperSet.prototype.fieldsFor = function (resource, block) {
          */
         input: function (name, params) {
             params = params || {};
-            if (params.value === undef) {
+            if (params.type === undef) {
+                params.type = 'text';
+            }
+            if (params.value === undef && params.type.toLowerCase() !== 'password') {
                 params.value = typeof resource[name] !== 'undefined' ? resource[name] : '';
             }
             return HelperSet.prototype.input_tag({


### PR DESCRIPTION
Inputs created with the form_for helper will now have `type="text"` per default. Also, if the user sets the `type` option to `password`, the form helper will not display the associated resource value anymore.
