### PR TITLE
HelperSet.prototype.formFor can now work without a block

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -286,17 +286,13 @@ HelperSet.prototype.formTag = function(params, block) {
     }
 
     // push output
-    var tagBeginBuf = HelperSet.prototype.form_tag_begin.call(this, params);
-    tagBeginBuf.forEach(function(line) {
-      buf.push( line );
-    });
-    // `buf = buf.concat(...)` failed here?!
+    buf.push( HelperSet.prototype.formTagBegin.call(this, params) );
     
     // function?
     if (typeof block === 'function') {
         block();
     }
-    buf.push( HelperSet.prototype.form_tag_end() );
+    buf.push( HelperSet.prototype.formTagEnd() );
 };
 HelperSet.prototype.form_tag = HelperSet.prototype.formTag;
 
@@ -378,20 +374,7 @@ HelperSet.prototype.fieldsFor = function (resource, formParams, block) {
          * For formFor() calls without passing a block
          */
         begin: function () {
-          var buf = arguments.callee.caller.buf;
-          if (!buf) buf = arguments.callee.caller.caller.buf;
-          if (!buf) buf = arguments.callee.caller.caller.caller.buf;
-
-          // form_tag_begin returns an array of buffered lines
-          // iterate over these lines, push them into the buffer
-          // and return the last line, so that the view engine
-          // pushes it into the buffer itself
-
-          var _buf = HelperSet.prototype.form_tag_begin.call(self, formParams);
-          for (var i = 0; i < _buf.length - 1; i++) {
-            buf.push(_buf[i]);
-          }
-          return _buf[_buf.length - 1];
+          return HelperSet.prototype.formTagBegin.call(self, formParams);
         },
         /**
          * Closing form tag
@@ -399,7 +382,7 @@ HelperSet.prototype.fieldsFor = function (resource, formParams, block) {
          * For formFor() calls without passing a block
          */
         end: function () {
-          return HelperSet.prototype.form_tag_end();
+          return HelperSet.prototype.formTagEnd();
         },
         /**
          * Input tag helper
@@ -612,9 +595,9 @@ HelperSet.prototype.form_for = HelperSet.prototype.formFor;
  *
  * @methodOf HelperSet.prototype
  * @param {Object} params - set of tag attributes
- * @returns {Array} Form tag with csrf_tag as well as method tag (as buffer)
+ * @returns {String} Form tag with csrf_tag as well as method tag
  */
-HelperSet.prototype.form_tag_begin = function (params) {
+HelperSet.prototype.formTagBegin = function (params) {
   // default method is POST
   if (!params.method) {
       params.method = 'POST';
@@ -633,14 +616,14 @@ HelperSet.prototype.form_tag_begin = function (params) {
   ['remote', 'jsonp', 'confirm'].forEach(dataParam.bind(params));
 
   // push output
-  var buf = [ '<form' + htmlTagParams(params) + '>' ];
-  buf.push( this.csrf_tag() );
+  var html = '<form' + htmlTagParams(params) + '>';
+  html += this.csrf_tag();
 
   // alternative method
   if(_method !== params.method) {
-    buf.push(HelperSet.prototype.input_tag({type: "hidden", name: "_method", value: _method }));
+    html += HelperSet.prototype.inputTag({type: "hidden", name: "_method", value: _method });
   }
-  return buf;
+  return html;
 };
 
 /**
@@ -649,7 +632,7 @@ HelperSet.prototype.form_tag_begin = function (params) {
  * @methodOf HelperSet.prototype
  * @returns {String} Closing tag for form
  */
-HelperSet.prototype.form_tag_end = function (params) {
+HelperSet.prototype.formTagEnd = function (params) {
   return '</form>';
 };
 
@@ -662,9 +645,10 @@ HelperSet.prototype.form_tag_end = function (params) {
  * @param {Object} override - set params to override params in previous arg 
  * @returns {String} Finalized input tag
  */
-HelperSet.prototype.input_tag = function (params, override) {
+HelperSet.prototype.inputTag = function (params, override) {
     return '<input' + htmlTagParams(params, override) + ' />';
 };
+HelperSet.prototype.input_tag = HelperSet.prototype.inputTag;
 
 /**
  * Label tag helper

--- a/test/helpers.coffee
+++ b/test/helpers.coffee
@@ -79,22 +79,21 @@ context 'formTag', (test) ->
     it 'should generate form', (test) ->
         buf = arguments.callee.buf = []
         railway.helpers.formTag()
-        test.equal(buf[1], '<input type="hidden" name="param_name" value="token_value" />')
+        test.equal(buf[0], '<form method="POST"><input type="hidden" name="param_name" value="token_value" />')
         test.done()
 
     it 'should generate form with custom method', (test) ->
         buf = arguments.callee.buf = []
         railway.helpers.formTag({method: 'PUT'})
-        test.equal(buf[0], '<form method="POST">')
-        test.equal(buf[2], '<input type="hidden" name="_method" value="PUT" />')
+        test.equal(buf[0], '<form method="POST"><input type="hidden" name="param_name" value="token_value" /><input type="hidden" name="_method" value="PUT" />')
         test.done()
 
     it 'should accept passed block', (test) ->
         buf = arguments.callee.buf = []
         railway.helpers.formTag ->
             buf.push 'BLOCK CONTENTS'
-        test.equal(buf[0], '<form method="POST">')
-        test.equal(buf[2], 'BLOCK CONTENTS')
+        test.equal(buf[0], '<form method="POST"><input type="hidden" name="param_name" value="token_value" />')
+        test.equal(buf[1], 'BLOCK CONTENTS')
         test.done()
 
     it 'should generate update form for resource with PUT method', (test) ->
@@ -104,8 +103,7 @@ context 'formTag', (test) ->
              "/resources/#{res.id}"
 
         railway.helpers.formFor res, {}, (f) -> return
-        test.equal(buf[0], '<form method="POST" action="/resources/7">')
-        test.equal(buf[2], '<input type="hidden" name="_method" value="PUT" />')
+        test.equal(buf[0], '<form method="POST" action="/resources/7"><input type="hidden" name="param_name" value="token_value" /><input type="hidden" name="_method" value="PUT" />')
         test.done()
 
     it 'should be able to create inputs without a block', (test) ->
@@ -118,6 +116,6 @@ context 'formTag', (test) ->
         buf.push f.begin()
         buf.push f.end()
 
-        test.equal(buf[0], '<form method="POST" action="/resources/7">')
-        test.equal(buf[2], '<input type="hidden" name="_method" value="PUT" />')
+        test.equal(buf[0], '<form method="POST" action="/resources/7"><input type="hidden" name="param_name" value="token_value" /><input type="hidden" name="_method" value="PUT" />')
+    
         test.done()


### PR DESCRIPTION
formFor can now be used without passing a block (since some view engines don't support blocks):

``` jade
- var f = formFor(resource, {})
= f.begin()
= f.submit()
= f.end()
```

Therefor, I created `HelperSet.prototype.form_tag_begin` and `HelperSet.prototype.form_tag_end`.

`form_tag_begin` returns a buffer (since we have multiple lines to render there) so we need to concatenate the render buffer and the buffer returned by the function. See lines 289-292 in helpers.js.
