### PR TITLE
AssetsCompiler now precompiles assets

### DIFF
--- a/lib/assets-compiler.js
+++ b/lib/assets-compiler.js
@@ -16,9 +16,34 @@ function AssetsCompiler(rw) {
     this.app = this.railway.app;
     this.cache = {};
     this.cssEngine = this.app.settings.cssEngine || 'stylus';
-
-    this.handleRequests();
 }
+
+AssetsCompiler.prototype.init = function() {
+    /** 
+     * Decide which asset directories to watch and which should
+     * be precompiled
+     */
+    var self = this
+      , precompiledAssetTypes = []
+      , handledAssetTypes = [];
+
+    ['javascripts', 'stylesheets'].forEach(function(assetType) {
+      if (self.app.enabled('merge ' + assetType)) {
+        precompiledAssetTypes.push(assetType);
+      } else {
+        handledAssetTypes.push(assetType);
+      }
+    });
+
+    if (precompiledAssetTypes.length > 0) {
+      // Compile assets asynchronously
+      process.nextTick(function() {
+        self.precompileAssets(precompiledAssetTypes);
+      });
+    }
+
+    this.handleRequests(handledAssetTypes);
+};
 
 AssetsCompiler.prototype.require = function(module) {
   return Module._load(module, {
@@ -27,16 +52,27 @@ AssetsCompiler.prototype.require = function(module) {
 };
 
 /**
+ * Precompiles assets in /app/assets/coffeescripts and /app/assets/stylesheets
+ * 
+ * @param {Array} List of asset types that should be precompiled
+ */
+AssetsCompiler.prototype.precompileAssets = function(assetTypes) {
+  log($('AssetsCompiler').bold + ' Precompiling assets: ' + assetTypes.join(', '));
+};
+
+/**
  * Listens to /stylesheets and /javascripts requests and
  * delegates the requests to the static middleware after
  * conditionally compiling the source files (e.g. coffee)
+ *
+ * @param {Array} List of asset types that should be compiled on request
  */
-AssetsCompiler.prototype.handleRequests = function() {
+AssetsCompiler.prototype.handleRequests = function(assetTypes) {
   var self = this;
   var staticMiddleware = require('express').static(self.app.root + '/public');
 
   // Catch requests to /javascripts and /stylesheets
-  this.app.get('/:folder(javascripts|stylesheets)/:file', function(req, res, next) {
+  this.app.get('/:folder(' + assetTypes.join('|') + ')/:file', function(req, res, next) {
     var folder = req.params.folder
       , fileName = req.params.file
       , options;
@@ -88,7 +124,7 @@ AssetsCompiler.prototype.handleRequests = function() {
  * Available compilers
  * 
  * {key} should be the `compiler` option passed 
- *   to AssetCompiler.prototype.compileAsset
+ *   to AssetsCompiler.prototype.compileAsset
  * {value} should be a function with two arguments:
  *   - the source code string
  *   - the callback function
@@ -144,7 +180,7 @@ AssetsCompiler.prototype.compilers = {
 AssetsCompiler.prototype.compileAsset = function(destFileName, options, fn) {
   var compile;
   if (!(compile = this.compilers[options.compiler])) {
-    log($('AssetCompiler').bold + ' failed: Compiler ' + $(options.compiler).bold + ' not implemented');
+    log($('AssetsCompiler').bold + ' failed: Compiler ' + $(options.compiler).bold + ' not implemented');
     return fn(null, false);
   }
 

--- a/lib/compound.js
+++ b/lib/compound.js
@@ -8,6 +8,7 @@ var existsSync = fs.existsSync || path.existsSync;
 var exists = fs.exists || path.exists;
 var cs = require('coffee-script');
 var Module = require('module').Module;
+var AssetsCompiler = require('./assets-compiler');
 
 /**
  * Global railway API singleton.
@@ -34,8 +35,7 @@ function Railway(app) {
     this.logger = require('./logger');
     this.logger.init(this);
 
-    this.AssetsCompiler = require('./assets-compiler');
-    var assets = this.assets = new this.AssetsCompiler(this);
+    this.assetsCompiler = new AssetsCompiler(this);
     
     this.ControllerBridge = require('./controller-bridge');
     this.controller = require('kontroller').BaseController;
@@ -86,6 +86,8 @@ exports.init = function initRailway(app) {
     // and environments/{test|development|production}.{js|coffee}
     configureApp(railway);
 
+    railway.assetsCompiler.init();
+
     // controllers should be loaded before extensions
     // railway.controller.init(root);
 
@@ -125,7 +127,6 @@ exports.init = function initRailway(app) {
             ensureDirClean(railway.app.root + '/public' +
                 railway.app.set('cssDirectory'), 'cache');
         }
-
     });
 
     return railway;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -197,9 +197,6 @@ function mergeFiles(app, scope, files) {
         // push resulted filename to result
         result.push(cached);
     } else {
-        // we have no cache at the moment, just return files
-        result = result.concat(minify);
-
         // if caching process is not started yet
         if (cached !== false) {
             // mark caching process as started
@@ -236,6 +233,8 @@ function mergeFiles(app, scope, files) {
             stream.on('close', function() {
                 merged[scope][digest] = ['cache', digest].join('_');
             });
+
+            result = [['cache', digest].join('_')];
         }
     }
     return result;


### PR DESCRIPTION
If `merge javascripts` or `merge stylesheets` is enabled, the AssetsCompiler will automatically precompile all assets found in app/assets/ and `javascriptIncludeTag` and `stylesheetsIncludeTag` generate a cache-url to the merged javascripts / stylesheets
