### PR TITLE
Add new configuration options to AssetsCompiler

### DIFF
--- a/lib/assets-compiler.js
+++ b/lib/assets-compiler.js
@@ -16,9 +16,11 @@ var log = utils.debug;
 var AssetsCompiler = module.exports = function AssetsCompiler(compound) {
     this.compound = compound;
     this.app = this.compound.app;
+    this.assetDir = this.app.root + '/app/assets';
+    this.publicDir = this.app.root + '/public';
     this.defaultCompilerOptions = {
-      sourceDir: this.app.root + '/app/assets',
-      destDir: this.app.root + '/public',
+      sourceDir: '',
+      destDir: '',
     };
     this.addCompilers();
 }
@@ -77,21 +79,23 @@ AssetsCompiler.prototype.precompileAssets = function(assetExtensions) {
 
   log($('AssetsCompiler').bold + ' ' + $('Precompiling assets:').cyan + ' ' + sourceExtensions.join(', '));
 
-  this.compound.utils.recursivelyWalkDir(this.defaultCompilerOptions.sourceDir, function(err, files) {
+  this.compound.utils.recursivelyWalkDir(this.assetDir, function(err, files) {
     if (err) throw err;
 
     files.forEach(function(file) {
       var match = file.match(new RegExp('^(.*)\/(.*)[.]('+sourceExtensions.join('|')+')$'));
       if(match) {
-        var path = match[1]
+        var source = match[0]
+          , folder = match[1]
           , fileName = match[2]
           , extension = match[3]
           , compiler = self.compilers[extension]
-          , folder = path.replace(compiler.sourceDir, '');
-        console.log(folder)
-        self.compileAsset(fileName, folder, compiler, function(err) {
+          , destFolder = folder.replace(self.assetDir+compiler.sourceDir, self.publicDir+compiler.destDir)
+          , dest = destFolder + '/' + fileName + '.' + compiler.destExtension;
+        
+        self.compileAsset(source, dest, compiler, function(err) {
           if (err) {
-            log($('AssetsCompiler').bold + ' ' + $('Compilation of ' + relativeFilePath + ' failed: ').red + err);
+            log($('AssetsCompiler').bold + ' ' + $('Compilation of ' + source.replace(self.assetDir, '') + ' failed: ').red + err);
           }
         });
       }
@@ -107,14 +111,19 @@ AssetsCompiler.prototype.precompileAssets = function(assetExtensions) {
  * @param {Array} List of asset types that should be compiled on request
  */
 AssetsCompiler.prototype.handleRequest = function(req, res, next, assetExtensions) {
-  var match;
-  if (match = req.path.match(new RegExp('^(.*)\/(.*)[.]('+assetExtensions.join('|')+')$'))) {
-    var folder = match[1]
+  var match
+    , path = this.publicDir + req.path;
+  if (match = path.match(new RegExp('^(.*)\/(.*)[.]('+assetExtensions.join('|')+')$'))) {
+    var dest = match[0]
+      , folder = match[1]
       , fileName = match[2]
       , extension = match[3]
-      , compiler = this.getCompiler(extension);
+      , compiler = this.getCompiler(extension)
+      , sourceFolder = folder.replace(self.publicDir+compiler.destDir, self.assetDir+compiler.sourceDir)
+      , source = sourceFolder + '/' + fileName + '.' + compiler.sourceExtension;
+
     if(compiler) {
-      this.compileAsset(fileName, folder, compiler, function(err) {
+      this.compileAsset(source, dest, compiler, function(err) {
         if (err) {
           throw new Error('Asset compilation failed: ' + err);
         }
@@ -156,20 +165,16 @@ AssetsCompiler.prototype.getCompiler = function(extension) {
  * @param {Object} compiler
  * @return {Boolean} whether a file has been compiled
  */
-AssetsCompiler.prototype.compileAsset = function(fileName, folder, compiler, callback) {
+AssetsCompiler.prototype.compileAsset = function(sourcePath, destPath, compiler, callback) {
   var self = this;
   if (!callback) var callback = function() {};
 
-  // build paths
-  var destFileName = fileName + '.' + compiler.destExtension
-    , sourceFileName = fileName + '.' + compiler.sourceExtension
-    , sourcePath = compiler.sourceDir + folder + '/' + sourceFileName
-    , destPath = compiler.destDir + folder +'/' + destFileName
-    , options = {
-      sourceDir:  compiler.sourceDir + folder,
-      destDir: compiler.destDir + folder,
-      sourceFileName: sourceFileName,
-      destFileName: destFileName
+  // options for compiler
+    var options = {
+      sourceDir:  sourcePath.match(/(.*)\/|\\/)[1],
+      destDir: destPath.match(/(.*)\//)[1],
+      sourceFileName: sourcePath.match(/([^/\\]+)$/)[1],
+      destFileName: sourcePath.match(/([^/\\]+)$/)[1]
     };
 
   // if `sourcePath` doesnt exist, we don't need to compile
@@ -206,7 +211,7 @@ AssetsCompiler.prototype.compileAsset = function(fileName, folder, compiler, cal
       fs.writeFileSync(destPath, compiledCode);
 
       callback(null, true);
-      log($('AssetsCompiler').bold + ' ' + $(sourceFileName).cyan + ' => ' + $(destFileName).green);
+      log($('AssetsCompiler').bold + ' ' + $(options.sourceFileName).cyan + ' => ' + $(options.destFileName).green);
     });
   } else {
     callback(null, false);
@@ -265,6 +270,8 @@ AssetsCompiler.prototype.addCompilers = function() {
         fn(err);
       }
     },
+    sourceDir: '/coffeescripts',
+    destDir: '/javascripts',
     sourceExtension: 'coffee',
     destExtension: 'js'
   });


### PR DESCRIPTION
New configuration options that allow the compilers in AssetsCompiler
to be configured without modifying the AssetsCompiler filer directly.
This also allows you to easily add new compilers.

This is just a first attempt. Does this seem like a good way to
configure the compilers?

Then you can do something like this in the environments file:

```
module.exports = function (compound) {

    var express = require('express'),
        app = compound.app,
        roots_css = require('roots-css');

    app.configure(function(){
        app.use(compound.assetsCompiler.configure('stylus', {
            use: roots_css() 
        }).init());
        app.use(express.static(app.root + '/public', {maxAge: 86400000}));
        app.set('view engine', 'ejs');
        app.set('view options', {complexNames: true});
        app.set('jsDirectory', '/javascripts/');
        app.set('cssDirectory', '/stylesheets/');
        app.set('cssEngine', 'stylus');
        app.use(express.bodyParser());
        app.use(express.cookieParser('secret'));
        app.use(express.session({secret: 'secret'}));
        app.use(express.methodOverride());
        app.use(app.router);
    });

};
```

Or you could do these configurations in an initializer.
