### PR TITLE
fix crud controller naming

### DIFF
--- a/lib/generators/crud_generator.js
+++ b/lib/generators/crud_generator.js
@@ -82,7 +82,7 @@ CrudGenerator.prototype.generateController = function () {
     'Model': camelize(model, true)
   };
 
-  this.copyKontroller('crud_controller_eval.{{ CODE }}', 'app/controllers/' + model + '_controller.{{ CODE }}', variables);
+  this.copyKontroller('crud_controller_eval.{{ CODE }}', 'app/controllers/' + models + '_controller.{{ CODE }}', variables);
 };
 
 /**


### PR DESCRIPTION
crud controller names should be pluralized (as expected by the generated routs)
