### PR TITLE
Fix some typos and minor wording issues in Markdown files

### DIFF
--- a/docs/sources/markdown/asset-compiler.md
+++ b/docs/sources/markdown/asset-compiler.md
@@ -12,7 +12,7 @@
 Environment Settings:
 
 in `/config/environment.js`
-use the AssetCompiler middleware and set you css engine
+use the AssetCompiler middleware to set your css engine
 
 ```
 ...
@@ -24,7 +24,7 @@ app.configure(function(){
 });
 ...
 ```
-This will compile stylus (or whatever you use as you css engine) files in
+This will compile stylus files (or whatever else you use as your css engine) in
 `/app/assets/stylesheets` into `/public/stylesheets` and `/app/assets/coffeescripts` into `/public/javascripts`
 
 ## Configuration
@@ -32,10 +32,10 @@ This will compile stylus (or whatever you use as you css engine) files in
 Configuration can be done either in an initializer or in the Environment file.
 
 Compilers should be configured using the `compound.assetCompiler.config(compilerName, options)` method.
-This method takes 2 params, the name of the compiler and an obje t containing the options to configure, 
-and returns `compound.assetCompiler` for chaining. the default compilers use the following options:
+This method takes two parameters, the name of the compiler and an object containing the options to configure, 
+and returns `compound.assetCompiler` for chaining. The default compilers use the following options:
 
-* render: a function to compile the source into js or css, see Adding Your Own Compiler for more details
+* render: a function to compile the source into js or css (see Adding Your Own Compiler for more details)
 * sourceExtension: `'coffee'`
 * destExtension: `'js'`
 * sourceDir: `''` or `'/coffeescripts'`
@@ -43,7 +43,7 @@ and returns `compound.assetCompiler` for chaining. the default compilers use the
 
 It may also contain any other options which can be accessed in the render function ( `this.myCustomOption` )
 
-configure the coffe compiler to look for coffe files in `assets/coffee` instead of `/assets/coffeescripts`:
+Configure the coffee compiler to look for coffee files in `assets/coffee` instead of `/assets/coffeescripts`:
 
 `/config/environment.js`
 
@@ -60,8 +60,8 @@ app.configure(function(){
 
 ## Compiler Specific Configuration
 
-### stylus:
-when using stylus you may want to use some custom configurations as described here: http://learnboost.github.com/stylus/docs/js.html
+### Stylus:
+When using stylus you may want to use some custom configurations as described here: http://learnboost.github.com/stylus/docs/js.html
 
 `/config/environment.js`
 
@@ -84,24 +84,24 @@ app.configure(function(){
 
 ## Adding Your Own Compiler
 
-Adding your own comiler can be done using `compound.assetCompiler.add(compilerName, options)`
+Adding your own compiler can be done using `compound.assetCompiler.add(compilerName, options)`
 
-options should contain the following:
-* render: a function to compile the source into js or css, see Adding Your Own Compiler for more details
+Options should contain the following:
+* render: a function to compile the source into js or css (see Adding Your Own Compiler for more details)
 * sourceExtension: `'coffee'`
 * destExtension: `'js'`
 * sourceDir: `''` or `'/coffeescripts'`
 * destDir: `''` or `'/javascripts'`
 * any other options your render function needs
 
-The render function takes the 3 arguments:
+The render function takes three arguments:
 
 1. src, a string containing the source of the file to be compiled
-2. options: sourceDir, destDir, sourceFileName, destFileName.  shouldn't be necassary in most cases
-3. callback: pass 2 arguements, error and the compiled source.
+2. options: sourceDir, destDir, sourceFileName, destFileName.  Shouldn't be necassary in most cases
+3. callback: pass two arguments, error and the compiled source.
 
 
-an example of how to add your own coffee compiler:
+An example of how to add your own coffee compiler:
 
 `/config/environment.js`
 

--- a/docs/sources/markdown/code-snippets.md
+++ b/docs/sources/markdown/code-snippets.md
@@ -77,7 +77,7 @@ module.exports = (compound) ->
 
 * <a href="http://groups.google.com/group/railwayjs/browse_thread/thread/592df72830898e9a" target="_blank">Discussion in Google Groups</a>
 * The solution is to use <a href="https://github.com/anatoliychakkaev/connect-form-sync" target="_blank">this middleware</a>
-* Check out <a href="https://github.com/anatoliychakkaev/railway-example-upload" target="_blank">example app</a>
+* Check out this <a href="https://github.com/anatoliychakkaev/railway-example-upload" target="_blank">example app</a>
 
 ```
 var form = require('connect-form-sync');

--- a/docs/sources/markdown/controllers.md
+++ b/docs/sources/markdown/controllers.md
@@ -4,7 +4,7 @@ In CompoundJS, a controller is a module that receives user input and initiates a
 
 ## Features overview
 
-Inside controller you can use following reserved global functions to control response:
+Inside controllers you can use following reserved global functions to control response:
 
 * <strong>render</strong> - render view template related to this action
 * <strong>send</strong> - send text, status code or json object to client
@@ -37,7 +37,7 @@ action('index', function () {
 });
 ```
 
-If you want to pass some data to the view, there are two ways to do it. First is to simply pass a hash containing the data:
+If you want to pass some data to the view, there are two ways to do it. The first is to simply pass a hash containing the data:
 
 ```
 action('index', function () {
@@ -45,7 +45,7 @@ action('index', function () {
 });
 ```
 
-and the second method is to set the properties of `this`:
+The second method is to set the properties of `this`:
 
 ```
 action('index', function () {
@@ -54,7 +54,7 @@ action('index', function () {
 });
 ```
 
-And if you want to render another view, just put its name as the first argument:
+If you want to render another view, just put its name as the first argument:
 
 ```
 action('update', function () {
@@ -75,7 +75,7 @@ action('update', function () {
 
 The `send` function is useful for debugging and one-page apps where you don't want to render a heavy template and just want to send text or JSON data.
 
-This function can be called with number (status code):
+This function can be called with a status code number:
 
 ```
 action('destroy', function () {
@@ -91,7 +91,7 @@ action('sayHello', function () {
 });
 ```
 
-or with object:
+or with an object:
 
 ```
 action('apiCall', function () {
@@ -110,7 +110,7 @@ redirect('http://example.com'); // redirect to another host
 
 ### flash()
 
-The `flash` function stores a message in the session for future displaying, this is a regular expressjs function, refer to [expressjs 2.0 guide](http://expressjs.com/2x/guide.html#req.flash%28%29 "Expressjs 2.0 guide") to learn how it works. Few examples:
+The `flash` function stores a message in the session to be displayed later.  This is a regular expressjs function (refer to [expressjs 2.0 guide](http://expressjs.com/2x/guide.html#req.flash%28%29 "Expressjs 2.0 guide") to learn how it works). Here are a few examples:
 
 `posts_controller.js`
 ```
@@ -133,7 +133,7 @@ This `create` action sends a flash info on success and a flash error on fail.
 
 To provide the ability of DRY-ing controller code and reusing common code parts, CompoundJS provides a few additional tools: method chaining and external controllers loading.
 
-To chain methods, you can use the `before` and`after` methods.
+To chain methods, you can use the `before` and `after` methods.
 
 `checkout_controller.js`
 ```
@@ -151,7 +151,7 @@ function prepareBasket () { next() }
 function loadProducts () { next() }
 ```
 
-In this example, `userRequired` will be called only for the`order` action, `prepareBasket` will be called for all actions except `order`, and `loadProducts` will be called only for the `products` and `featuredProducts`methods.
+In this example, `userRequired` will be called only for the `order` action, `prepareBasket` will be called for all actions except `order`, and `loadProducts` will be called only for the `products` and `featuredProducts`methods.
 
 Note, that the before-functions should call the global `next` method that will pass control to the next function in the chain.
 

--- a/docs/sources/markdown/generators.md
+++ b/docs/sources/markdown/generators.md
@@ -12,7 +12,7 @@ or using the shortcut:
 compound g GENERATOR_NAME
 ```
 
-Built-in generators are:`model`, `controller`, `scaffold` (alias: `crud`)
+Built-in generators are: `model`, `controller`, `scaffold` (alias: `crud`)
 
 ## Generate model
 

--- a/docs/sources/markdown/heroku.md
+++ b/docs/sources/markdown/heroku.md
@@ -1,6 +1,6 @@
 # Heroku
 
-Heroku's Node.js hosting is available fo public usage now. Deploying a CompoundJS application is as simple as `git push`.
+Heroku's Node.js hosting is available for public use now. Deploying a CompoundJS application is as simple as `git push`.
 
 To work with heroku you also need `ruby` as well as the `heroku` gem.
 
@@ -77,7 +77,7 @@ To access the CompoundJS REPL console, do:
 heroku run compound console
 ```
 
-MongoHQ provides a web interface for browsing your MongoDB database, to use it go to `http://mongohq.com/`, create an account, then click "Add remote connection" and configure the link to your database. You can retrieve defails required for the connection using this command:
+MongoHQ provides a web interface for browsing your MongoDB database, to use it go to `http://mongohq.com/`, create an account, then click "Add remote connection" and configure the link to your database. You can retrieve details required for the connection using this command:
 
 ```
 heroku config --long

--- a/docs/sources/markdown/repl.md
+++ b/docs/sources/markdown/repl.md
@@ -14,7 +14,7 @@ compound c
 
 The REPL console is   just a simple Node.js console with some CompoundJS, for example models.
 
-Just one note on working with the console: Node.js is asynchronous by its nature which makes console debugging much more compilcated, since you have to use a callback to fetch results from the database for instance. We have added one useful method to simplify asynchronous debugging using the REPL console. It's called `c` and you can pass it as a parameter to any function that requires a callback. It will store the parameters passed to the callback to variables called `_0, _1, ..., _N` where N is the length of `arguments`.
+Just one note on working with the console: Node.js is asynchronous by nature which makes console debugging much more complicated, since you have to use a callback to fetch results from the database for instance. We have added one useful method to simplify asynchronous debugging using the REPL console. It's called `c` and you can pass it as a parameter to any function that requires a callback. It will store the parameters passed to the callback to variables called `_0, _1, ..., _N` where N is the length of `arguments`.
 
 Example:
 


### PR DESCRIPTION
I noticed there were some typos on the [Compound docs](http://compoundjs.com/docs.html) page, so I went through the Markdown files in `/docs/sources/markdown/` and fixed some remaining, unfixed typos and wording issues.
