### PR TITLE
when logger filter operations are performed null fields are now supported

### DIFF
--- a/lib/server/controller-bridge.js
+++ b/lib/server/controller-bridge.js
@@ -189,7 +189,7 @@ ControllerBrigde.prototype.getInstance = function getInstance(name) {
             if (req.body && req.method !== 'GET') {
                 var filterParams = ctl.constructor.filterParams || [];
                 var filteredBody = (function filter(obj) {
-                    if (typeof obj !== 'object') {
+                    if (typeof obj !== 'object' || obj == null) {
                         return obj;
                     }
                     var filtered = {};


### PR DESCRIPTION
Hi Anatolly,

  I found a little but that prevents to post data with null field to a compound controller (logger filter crashes on null field). Normally this modification solves the problem.

Frank
