### PR TITLE
When app mounted grab models from parent app

### DIFF
--- a/lib/compound.js
+++ b/lib/compound.js
@@ -22,6 +22,12 @@ function Compound(app, root) {
     this.controllerExtensions = require('./controller-extensions');
     this.helpers = require('./helpers');
 
+    app.on('mount', function(parent) {
+        if (parent.compound) {
+            this.models = parent.compound.models;
+        }
+    }.bind(this));
+
     app.compound = this;
     app.models = this.models;
 


### PR DESCRIPTION
This is experimental stuff on sharing models. Idea is simple: child app can access parent app models and add new models to parent app (or extend existing). Using this technique it's possible to share models / partially define models in different modules.

Possible problem. This solution only works when applications mounted from root to leafs, when some branch built it can not be added to some app root subtree without loosing models already defined branch.

Need to think more about it
