### PR TITLE
Fix normalizing of view paths with multiple \

### DIFF
--- a/lib/controller-extensions.js
+++ b/lib/controller-extensions.js
@@ -78,7 +78,7 @@ Controller.prototype.render = function(arg1, arg2) {
     } else {
         layout = this.layout();
     }
-    var file = path.normalize(this.controllerName + '/' + view).replace("\\", "/");
+    var file = path.normalize(this.controllerName + '/' + view).replace(/\\/g, "/");
 
     if (this.logger) {
         this.logger.emit('render', file, layout);


### PR DESCRIPTION
The string.replace function with a string as the pattern only replaces the first instance.
Using a regex, we ensure we'll replace every \ with /
