### PR TITLE
Fix for replace of \ in view name under windows

### DIFF
--- a/lib/controller-extensions.js
+++ b/lib/controller-extensions.js
@@ -78,7 +78,7 @@ Controller.prototype.render = function(arg1, arg2) {
     } else {
         layout = this.layout();
     }
-    var file = path.normalize(this.controllerName + '/' + view).replace("\\", "/");
+    var file = path.normalize(this.controllerName + '/' + view).replace(/\\/g, "/");
 
     if (this.logger) {
         this.logger.emit('render', file, layout);


### PR DESCRIPTION
The current replace only replaces one \ thus failling with names with multiples .
The regex will replace everything
