### PR TITLE
Changed deprecated jQuery .live to .on in rails.js.

### DIFF
--- a/templates/public/javascripts/rails.js
+++ b/templates/public/javascripts/rails.js
@@ -131,7 +131,7 @@ jQuery(function ($) {
         $(this).find(disable_with_input_selector).each(function () {
             var input = $(this);
             input.data('enable-with', input.val())
-                .attr('value', input.attr('danta-disable-with'))
+                .attr('value', input.attr('data-disable-with'))
                 .attr('disabled', 'disabled');
         });
     };


### PR DESCRIPTION
Fixed errors when using jQuery 1.9+ in rails.js. Updated deprecated .live to .on. 
