### PR TITLE
Update for express@3.3.2

### DIFF
--- a/lib/server/compound.js
+++ b/lib/server/compound.js
@@ -154,9 +154,6 @@ exports.createServer = function(options) {
     var app = express(options);
     var compound = new CompoundServer(app, root, options);
 
-    app.express2 = !!express.version.match(/^2/);
-    app.express3 = !!express.version.match(/^3/);
-
     return app;
 };
 


### PR DESCRIPTION
Express 3.3.2 have no `version` property, so this code throws a type exception. Just removed useless code.
