### PR TITLE
Fix 'npm install compound' Error: No compatible version found: kontroller@'>=0.0.9'

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ejs-ext": ">= 0.1.4-2",
     "jade-ext": ">= 0.0.5",
     "railway-routes": ">= 0.0.6",
-    "kontroller": ">= 0.0.9",
+    "kontroller": ">= 0.0.9-0",
     "inflection": "~1.2.5"
   },
   "repository": {


### PR DESCRIPTION
After updating npm, it failed to install compound.

Maybe there is a better solution, but this hack fixed my problem.

Error message running `npm install compound`:

```
npm ERR! Error: No compatible version found: kontroller@'>=0.0.9'
npm ERR! Valid install targets:
npm ERR! ["0.0.0","0.0.1","0.0.2","0.0.3","0.0.5","0.0.6","0.0.7","0.0.8","0.0.8-1","0.0.8-2","0.0.9-0","0.0.9-1","0.0.9-2","0.0.9-3","0.0.9-4","0.0.9-5","0.0.9-6","0.0.9-7","0.0.9-8","0.0.9-9","0.0.9-10","0.0.9-11","0.0.9-12","0.0.9-13","0.0.9-14","0.0.9-15","0.0.9-16"]
npm ERR!     at installTargetsError (/usr/lib/node_modules/npm/lib/cache.js:722:10)
npm ERR!     at next (/usr/lib/node_modules/npm/lib/cache.js:701:17)
npm ERR!     at /usr/lib/node_modules/npm/lib/cache.js:678:5
npm ERR!     at saved (/usr/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:138:7)
npm ERR!     at Object.oncomplete (fs.js:107:15)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
```
