### PR TITLE
New optional virtual host (vhost) feature for routes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ compound-changelog(3) -- Changes in CompoundJS
 
 - Fixed HTTPS support
 - Introduce `req.locals` API to early access controller action context (`this`).
+- Added `vhost` route option.
 
 ### 1.1.6
 

--- a/docs/api/routing.md
+++ b/docs/api/routing.md
@@ -108,13 +108,31 @@ Specify custom URL helper name
     pathTo.myAction() => '/some/action'
 
 * `subdomain`:
-Check HOST header when matching request, use \* as wildcard domain:
+Check HTTP/1.1 Host header when matching request, use \* as wildcard domain:
 
     map.get('/url', 'ctl#action', {subdomain: 'subdomain.tld'});
     map.get('/url', 'ctl#action', {subdomain: '*.example.com'});
 
-*NOTE*: This feature relies on `host` header, if your node process behind nginx
-or proxy, make sure you've passed this header to process.
+A subdomain match will ignore the first- and second-level components of the
+domain. This value is hard-coded into the `ControllerBrigde` class.
+
+*NOTE*: This feature relies on `Host` HTTP/1.1 header, if your Node process
+behind a proxy (like Nginx), make sure you've passed this header to CompoundJS.
+
+* `vhost`:
+Constrains the route match to include the given virtual host name
+
+    map.get('/apples/:id', 'fruit#action', {vhost: '.fruit.com'});
+    map.get('/carrots/:id', 'vegetable#action', {vhost: 'vegetables.com'});
+
+In the examples above, the `/apples/:id` route matches `http://fruit.com` and
+`http://*.fruit.com`, while the `/carrots/:id` route will only match
+`http://vegetables.com`.
+
+Compared to the `subdomain` option, the `vhost` option allows for a more
+straightforward route constraint on domain name.
+
+*NOTE*: Like the `subdomain` feature, this relies on `Host` HTTP/1.1 header.
 
 ## URL HELPERS
 

--- a/lib/controller-bridge.js
+++ b/lib/controller-bridge.js
@@ -68,12 +68,68 @@ ControllerBrigde.prototype.uniCaller = function(ns, controller, action, conf) {
 
     return function(req, res, next) {
 
-        var subdomain = req.headers && req.headers.host && req.headers.host
-            .split('.')
-            .slice(0, -1 * ControllerBrigde.config.subdomain.tld);
+        // Request hostname, or null if unknown
+        var hostname =
+            (req.headers && req.headers.host && req.headers.host.length)
+                ? req.headers.host.toLowerCase()
+                : null;
+
+        var subdomain = req.headers && req.headers.host &&
+            req.headers.host
+                .split('.')
+                .slice(0, -1 * ControllerBrigde.config.subdomain.tld);
         req.subdomain = subdomain && subdomain.join('.');
 
-        if (conf && conf.subdomain && req.subdomain) {
+        // Virtual Host match?
+        if (conf && conf.vhost && conf.vhost.length && hostname) {
+
+            // Virtual host is a wildcard?
+            var wildcard = (conf.vhost.charAt(0) === '.');
+
+            // Virtual host name (without leading wildcard character, if any)
+            var vhost =
+                (wildcard)
+                    ? conf.vhost.substring(1).toLowerCase()
+                    : conf.vhost.toLowerCase();
+
+            // Compare without regard to port number if the configuration vhost
+            // does not specify a port number. This lets us work with a proxy-
+            // server with little complication.
+            if (vhost.indexOf(":") < 0) {
+                // Strip port number from the request hostname
+                var portIndex = hostname.indexOf(":");
+                if (portIndex >= 0) {
+                    hostname = hostname.substring(0, portIndex);
+                }
+            }
+
+            // Does the request match the Virtual Host?
+            var match;
+
+            // Wildcard virtual host: ".example.com" (12 chars) should match:
+            //  1. "www.example.com" (15 chars)
+            //  2.     "example.com" (11 chars)
+            if (wildcard) {
+                // Condition #1 above
+                match =
+                    (hostname.length > vhost.length) &&
+                    (hostname.indexOf("." + vhost) === (hostname.length - conf.vhost.length));
+
+                // Condition #2 above
+                match = match || (vhost === hostname);
+            }
+            // Virtual Host exact match
+            else {
+                match = (vhost === hostname);
+            }
+
+            if (!match) {
+                // Virtual Host mismatch: go to the next route
+                return next();
+            }
+        }
+        // Subdomain match?
+        else if (conf && conf.subdomain && req.subdomain) {
             if (conf.subdomain !== req.subdomain) {
                 if (conf.subdomain.match(/\*/)) {
                     var matched = true;


### PR DESCRIPTION
A straightforward alternative to the existing [subdomain route option](http://compoundjs.com/docs/#routing-subdomain).

In the CompoundJS application `config/route.coffee` file, add the vhost option in the 3rd parameter dictionary:

```
  exports.routes = (map) ->
    map.get "/apples/:id", "fruit#action", {vhost: ".fruit.com"}
    map.get "/carrots/:id", "vegetable#action", {vhost: "vegetables.com"}
```

where the `vhost` value is similar to what you would see in a Nginx `server_name` directive:
1. Hostnames starting with a period (".") are treated like wildcards.  The first example above matches both "fruit.com" and "www.fruit.com"
2. Are otherwise are treated as exact matches.  The second example above only matches "vegetables.com".
