### PR TITLE
Added history file in temp directory.

### DIFF
--- a/lib/server/tools.js
+++ b/lib/server/tools.js
@@ -201,7 +201,7 @@ function railwayConsole(compound, args) {
         });
         fs.readFile(historyFile, {encoding: 'utf8'}, function(err, data) {
             if (err) {
-                return console.log('Could not read history file', err);
+                return;
             }
             // Remove the last element (newline)
             var history = data.split('\n').slice(1);


### PR DESCRIPTION
Command line history kept in OS temp directory and limited according to node's default repl history (30 commands at the moment). Don't think we need to specify a different length, but we can if we need to.
