### PR TITLE
Implemented unix-style reverse history search

### DIFF
--- a/lib/server/tools.js
+++ b/lib/server/tools.js
@@ -2,7 +2,6 @@ var path = require('path'),
     net = require('net'),
     fs = require('fs'),
     os = require('os'),
-    path = require('path'),
     readline = require('readline'),
     childProcess = require('child_process'),
     sys = require('util'),
@@ -195,6 +194,10 @@ function railwayConsole(compound, args) {
 
         // Set up cli history
         var historyFile = path.join(os.tmpdir(), '.compound_history');
+        var historySearchMode = false;
+        var historySearchString = '';
+        var historySearchPrompt = '(history-search)`%`:';
+        var _ttyWrite = repl.rli._ttyWrite;
         repl.rli.on('line', function(line) {
             // Write to history file
             fs.appendFile(historyFile, '\n' + line);
@@ -207,6 +210,83 @@ function railwayConsole(compound, args) {
             var history = data.split('\n').slice(1);
             repl.rli.history = history.reverse();
         });
+        // Search through cli history
+        repl.rli.input.on('keypress', function(s, key) {
+            if (!key) return;
+            if (historySearchMode) {
+                if (key.name === 'return' || key.name === 'enter' || key.name === 'linefeed') {
+                    // Done searching, run command
+                    handleHistory(true);
+                    return;
+                }
+                if (key.name === 'left' || key.name === 'right') {
+                    handleHistory(false);
+                    return;
+                }
+                return;
+            }
+            if (key.ctrl && key.name === 'r') {
+                repl.prompt = historySearchPrompt;
+                repl.rli._ttyWrite = ttyWriteHistory;
+                historySearchMode = true;
+                historySearchString = repl.rli.line;
+                repl.rli.line = '';
+                refreshHistoryPrompt();
+                return;
+            }
+        });
+        function ttyWriteHistory(s, key) {
+            if (!key) {
+                historySearchString += s;
+                refreshHistoryPrompt();
+                return;
+            }
+            if (key.name.length === 1) {
+                historySearchString += key.name;
+                refreshHistoryPrompt();
+                return;
+            }
+            if (key.name === 'backspace') {
+                historySearchString = historySearchString.substr(0, historySearchString.length - 1);
+                refreshHistoryPrompt();
+                return;
+            }
+            if (key.name === 'space') {
+                historySearchString += ' ';
+                refreshHistoryPrompt();
+                return;
+            }
+        }
+        function refreshHistoryPrompt() {
+            repl.prompt = historySearchPrompt.split('%').join(historySearchString);
+            repl.rli.line = matchHistory(historySearchString);
+            repl.displayPrompt();
+        }
+        function matchHistory(match) {
+            if (match.length < 1) return '';
+            // Search through the repl.rli.history array for a match
+            for (var i = 0; i < repl.rli.history.length; ++i) {
+                if (repl.rli.history[i].match(match)) {
+                    repl.rli.historyIndex = i;
+                    return repl.rli.history[i];
+                }
+            }
+            return '';
+        }
+        function handleHistory(run) {
+            historySearchMode = false;
+            repl.prompt = 'compound> ';
+            repl.displayPrompt();
+            repl.rli._ttyWrite = _ttyWrite;
+            if (run) {
+                console.log('');
+                var cmd = repl.rli.line;
+                repl.rli.line = '';
+                repl.rli._onLine(cmd);
+                repl.displayPrompt();
+            }
+            historySearchString = '';
+        }
 
         repl.on('exit', function() {
             // Overwrite history file to remove old data


### PR DESCRIPTION
Added cli history search, similar to linux. Usage:

`ctrl+r` `part-of-command`

`enter` to run, `leftarrow` or `rightarrow` to edit the command. Unlike the standard linux reverse-i-search, this one does not show the last matching command if the pattern is not found.
