### PR TITLE
Added GeneratorUtilities.prototype.isBaseDirExists function.

### DIFF
--- a/lib/server/generators/app_generator.js
+++ b/lib/server/generators/app_generator.js
@@ -47,7 +47,9 @@ AppGenerator.prototype.perform = function (args) {
   if (this.options.appName) {
     this.baseDir = path.join(this.baseDir, this.options.appName);
   }
-
+  if (this.isBaseDirExists()) {
+    return;
+  }
   this.createDirectoryStructure();
   this.copyFiles();
 };

--- a/lib/server/generators/generator_utils.js
+++ b/lib/server/generators/generator_utils.js
@@ -425,7 +425,7 @@ GeneratorUtilities.prototype.getDatabaseDependency = function() {
     }
 };
 
-GeneratorUtilities.prototype.isEvalAllowed = function () {
+GeneratorUtilities.prototype.isEvalAllowed = function() {
   return !('noeval' in this.options);
 };
 
@@ -434,6 +434,14 @@ GeneratorUtilities.prototype.generateSecret = function() {
     .createHash('sha1')
     .update(Math.random().toString())
     .digest('hex');
+};
+
+GeneratorUtilities.prototype.isBaseDirExists = function() {
+  var exists = fs.existsSync(this.baseDir);
+  if (exists) {
+    this.log($('"' + this.baseDir + '" exists', this.baseDir).bold.red);
+  }
+  return exists;
 };
 
 module.exports = GeneratorUtilities;


### PR DESCRIPTION
Prevent compound to create base directory when it already exists.

Today I just ran into problem when I have `blog` directory in my working directory.
I fired up `compound init blog && cd blog` and see this directory is kinda weird there are `Gemfile`, `Rakefile` and other Rails stuffs mixed with compound files.

So this commit fixed that.

P.S. I saw coding styles are not consistent, we could use jshint or some linter :smiley:
