### PR TITLE
register coffeescript compiler

### DIFF
--- a/bin/compound.js
+++ b/bin/compound.js
@@ -10,7 +10,7 @@ try {
         process.exit();
     }
     if (package.main.match(/\.coffee$/)) {
-        require('coffee-script');
+        require('coffee-script/register');
     }
     instantiateApp = require(process.cwd());
 } catch(e) {


### PR DESCRIPTION
It sould be 'coffee-script/register' since 1.7.0  => http://coffeescript.org/#changelog
