### PR TITLE
render should only call next after the rendering engine is done

### DIFF
--- a/lib/controller-extensions.js
+++ b/lib/controller-extensions.js
@@ -75,7 +75,20 @@ Controller.prototype.render = function render(view, params, callback) {
     file = calcView(compound, file, params);
 
     if (!layout) {
-        return self.renderView(file);
+        return self.renderView(file, function(err, html) {
+            if(err) {
+                return self.next(err);
+            }
+
+            if (self.logger) {
+                self.logger.emit('render', file, "NONE", Date.now() - start);
+            }
+
+            self.res.send(html);
+            if (self.context.inAction) {
+                return self.next();
+            }
+        });
     }
 
     self.renderView(file, function(err, html) {
@@ -83,11 +96,20 @@ Controller.prototype.render = function render(view, params, callback) {
             return self.next(err);
         }
         self.viewContext.body = html;
-        self.renderView(layout);
-        if (self.logger) {
-            self.logger.emit('render', file, layout, Date.now() - start);
-        }
+        self.renderView(layout, function(err, html) {
+            if(err) {
+                return self.next(err);
+            }
 
+            if (self.logger) {
+                self.logger.emit('render', file, layout, Date.now() - start);
+            }
+
+            self.res.send(html);
+            if (self.context.inAction) {
+                return self.next();
+            }
+        });
     });
 
     function getLayoutName() {
@@ -152,14 +174,7 @@ Controller.prototype.renderView = function renderView(view, callback) {
             throw err;
         }
     }
-    if (callback) {
-        this.res.render(filename, this.viewContext, callback);
-    } else {
-        this.res.render(filename, this.viewContext);
-        if (this.context.inAction) {
-            this.next();
-        }
-    }
+    this.res.render(filename, this.viewContext, callback);
 };
 
 Controller.prototype.helpers = function () {


### PR DESCRIPTION
With ejs 2.x, compound stops working.

The reason is that the current code assumes the render engine is synchronous and calls next after making its last render call. This is not a valid expectation (ejs does not follow this).

With this change, next is only called after the full rendering is done.

Fix compoundjs with ejs 2.x (1.x still works)
